### PR TITLE
RNP-80: Refactor redundant 'as String'

### DIFF
--- a/ios/Connectors/RegistrationConnector.swift
+++ b/ios/Connectors/RegistrationConnector.swift
@@ -17,7 +17,7 @@ class RegistrationConnector : BridgeToRegistrationConnectorProtocol {
     func handleCustomRegistrationAction(_ action: String, _ identityProviderId: String, _ code: String? = nil) -> Void {
         switch action {
             case CustomRegistrationAction.provide.rawValue:
-                registrationHandler.processOTPCode(code: code as String?)
+                registrationHandler.processOTPCode(code: code)
                 break
             case CustomRegistrationAction.cancel.rawValue:
                 registrationHandler.cancelCustomRegistration()

--- a/ios/Handlers/PinHandler.swift
+++ b/ios/Handlers/PinHandler.swift
@@ -89,7 +89,7 @@ extension PinHandler : PinConnectorToPinHandler {
     }
 
     func onPinProvided(pin: String) {
-      let characters: String = pin as String
+      let characters: String = pin
       let pinArray: Array<String> = Array(arrayLiteral: characters)
 
       processPin(pinEntry: pinArray)

--- a/ios/RNOneginiSdk.swift
+++ b/ios/RNOneginiSdk.swift
@@ -149,7 +149,7 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
 
     @objc
     func handleRegistrationCallback(_ url: String) -> Void {
-        bridgeConnector.toRegistrationConnector.registrationHandler.processRedirectURL(url: URL(string: url as String)!)
+        bridgeConnector.toRegistrationConnector.registrationHandler.processRedirectURL(url: URL(string: url)!)
     }
 
     @objc
@@ -208,7 +208,7 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
     func startSingleSignOn(_ url: String,
                         resolver resolve: @escaping RCTPromiseResolveBlock,
                         rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        let _url = URL(string: url as String)
+        let _url = URL(string: url)
 
         bridgeConnector.toAppToWebHandler.signInAppToWeb(targetURL: _url, completion: { (result, error) in
             if let error = error {
@@ -283,7 +283,7 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
     func handleMobileAuthWithOtp(_ otpCode: String,
                         resolver resolve: @escaping RCTPromiseResolveBlock,
                         rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        bridgeConnector.toMobileAuthConnector.mobileAuthHandler.handleOTPMobileAuth(otpCode as String) {
+        bridgeConnector.toMobileAuthConnector.mobileAuthHandler.handleOTPMobileAuth(otpCode) {
             (_ , error) -> Void in
 
             if let error = error {
@@ -345,9 +345,9 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
     func setPreferredAuthenticator(_ profileId: String, authenticatorId: String,
                         resolver resolve: @escaping RCTPromiseResolveBlock,
                         rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        let profile = userClient.userProfiles().first(where: { $0.profileId == profileId as String })!
+        let profile = userClient.userProfiles().first(where: { $0.profileId == profileId })!
 
-        bridgeConnector.toAuthenticatorsHandler.setPreferredAuthenticator(profile, authenticatorId as String) {
+        bridgeConnector.toAuthenticatorsHandler.setPreferredAuthenticator(profile, authenticatorId) {
             (_ , error) -> Void in
 
             if let error = error {
@@ -365,7 +365,7 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
     func registerFingerprintAuthenticator(_ profileId: String,
                         resolver resolve: @escaping RCTPromiseResolveBlock,
                         rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        let profile = userClient.userProfiles().first(where: { $0.profileId == profileId as String})!
+        let profile = userClient.userProfiles().first(where: { $0.profileId == profileId})!
 
         bridgeConnector.toAuthenticatorsHandler.registerAuthenticator(profile, ONGAuthenticatorType.biometric) {
             (_ , error) -> Void in
@@ -382,7 +382,7 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
     func deregisterFingerprintAuthenticator(_ profileId: String,
                         resolver resolve: @escaping RCTPromiseResolveBlock,
                         rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        let profile = userClient.userProfiles().first(where: { $0.profileId == profileId as String })!
+        let profile = userClient.userProfiles().first(where: { $0.profileId == profileId })!
 
         bridgeConnector.toAuthenticatorsHandler.deregisterAuthenticator(profile, ONGAuthenticatorType.biometric) {
             (_ , error) -> Void in
@@ -399,7 +399,7 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
     func isFingerprintAuthenticatorRegistered(_ profileId: String,
                         resolver resolve: @escaping RCTPromiseResolveBlock,
                         rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        let profile = userClient.userProfiles().first(where: { $0.profileId == profileId as String })!
+        let profile = userClient.userProfiles().first(where: { $0.profileId == profileId })!
         let isAuthenticatorRegistered = bridgeConnector.toAuthenticatorsHandler.isAuthenticatorRegistered(ONGAuthenticatorType.biometric, profile)
 
         resolve(isAuthenticatorRegistered)


### PR DESCRIPTION
We left some redudant casts to swift String when we refactored all the
NSString to Swift String. This commit removes those.