### PR TITLE
RNP-100: iOS: Update handleRegistrationCallback

### DIFF
--- a/ios/OneginiWrapperErrors.swift
+++ b/ios/OneginiWrapperErrors.swift
@@ -4,6 +4,7 @@ enum WrapperError : Error {
     case malformedUrl
     case parametersNotCorrect
     case noProfileAuthenticated
+    case registrationNotInProgress
     
     var description: String {
         switch self {
@@ -17,6 +18,8 @@ enum WrapperError : Error {
             return "The supplied parameters are not correct"
         case .noProfileAuthenticated:
             return "No profile is currently authenticated"
+        case .registrationNotInProgress:
+            return "Registration is currently not in progress"
         }
     }
     var code: Int {
@@ -31,6 +34,8 @@ enum WrapperError : Error {
             return 8010
         case .noProfileAuthenticated:
             return 8011
+        case .registrationNotInProgress:
+            return 8012
         }
     }
 }

--- a/ios/RNOneginiSdk.swift
+++ b/ios/RNOneginiSdk.swift
@@ -182,8 +182,11 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
             return
         }
 
-        bridgeConnector.toRegistrationConnector.registrationHandler.processRedirectURL(url: urlOBject)
-        resolve(nil)
+        if (bridgeConnector.toRegistrationConnector.registrationHandler.processRedirectURL(url: urlOBject)) {
+            resolve(nil)
+        } else {
+            reject(String(WrapperError.registrationNotInProgress.code), WrapperError.registrationNotInProgress.description, WrapperError.registrationNotInProgress)
+        }
     }
 
     @objc


### PR DESCRIPTION
iOS was not rejecting when no registration was in progress. This commit adds that functionality. It also does a small refactor for how cancelRegistration is handled internally.