### PR TITLE
Remove unnecessary getters in custom registration providers

### DIFF
--- a/android/src/main/java/com/onegini/mobile/sdk/reactnative/handlers/customregistration/SimpleCustomRegistrationAction.kt
+++ b/android/src/main/java/com/onegini/mobile/sdk/reactnative/handlers/customregistration/SimpleCustomRegistrationAction.kt
@@ -4,8 +4,6 @@ import com.onegini.mobile.sdk.android.handlers.action.OneginiCustomRegistrationA
 
 interface SimpleCustomRegistrationAction: OneginiCustomRegistrationAction {
 
-    fun getOneginiCustomRegistrationAction(): OneginiCustomRegistrationAction
-
     fun getIdProvider(): String
 
     fun returnSuccess(result: String?)

--- a/android/src/main/java/com/onegini/mobile/sdk/reactnative/handlers/customregistration/SimpleCustomRegistrationActionImpl.kt
+++ b/android/src/main/java/com/onegini/mobile/sdk/reactnative/handlers/customregistration/SimpleCustomRegistrationActionImpl.kt
@@ -42,10 +42,6 @@ class SimpleCustomRegistrationActionImpl(
         return callback != null
     }
 
-    override fun getOneginiCustomRegistrationAction(): OneginiCustomRegistrationAction {
-        return this
-    }
-
     override fun getIdProvider(): String {
         return idProvider
     }

--- a/android/src/main/java/com/onegini/mobile/sdk/reactnative/handlers/customregistration/SimpleCustomRegistrationProvider.kt
+++ b/android/src/main/java/com/onegini/mobile/sdk/reactnative/handlers/customregistration/SimpleCustomRegistrationProvider.kt
@@ -10,6 +10,6 @@ class SimpleCustomRegistrationProvider(val action: SimpleCustomRegistrationActio
     }
 
     override fun getRegistrationAction(): OneginiCustomRegistrationAction {
-        return action.getOneginiCustomRegistrationAction()
+        return action
     }
 }

--- a/android/src/main/java/com/onegini/mobile/sdk/reactnative/handlers/customregistration/SimpleCustomTwoStepRegistrationActionImpl.kt
+++ b/android/src/main/java/com/onegini/mobile/sdk/reactnative/handlers/customregistration/SimpleCustomTwoStepRegistrationActionImpl.kt
@@ -24,10 +24,6 @@ class SimpleCustomTwoStepRegistrationActionImpl(
         eventEmitter.finishRegistration(idProvider, info)
     }
 
-    override fun getOneginiCustomRegistrationAction(): OneginiCustomRegistrationAction {
-        return this
-    }
-
     override fun getIdProvider(): String {
         return idProvider
     }


### PR DESCRIPTION
There were some old getters which were not removed in previous refactor. This commit removes them :^)