### PR TITLE
RNP-144: Move login/register to swift api + fix deadlock during auth

### DIFF
--- a/ios/Handlers/ChangePinHandler.swift
+++ b/ios/Handlers/ChangePinHandler.swift
@@ -25,31 +25,35 @@ class ChangePinHandler: NSObject {
 
 extension ChangePinHandler: PinConnectorToPinHandler {
     func onChangePinCalled(completion: @escaping (Error?) -> Void) {
-        ONGUserClient.sharedInstance().changePin(self)
+        SharedUserClient.instance.changePin(delegate: self)
         changePinCompletion = completion
     }
  }
 
-extension ChangePinHandler: ONGChangePinDelegate {
-    func userClient(_ userClient: ONGUserClient, didReceive challenge: ONGPinChallenge) {
+extension ChangePinHandler: ChangePinDelegate {
+    func userClient(_ userClient: UserClient, didReceivePinChallenge challenge: PinChallenge) {
         loginHandler.handleDidReceiveChallenge(challenge)
     }
 
-    func userClient(_: ONGUserClient, didReceive challenge: ONGCreatePinChallenge) {
+    func userClient(_ userClient: UserClient, didReceiveCreatePinChallenge challenge: CreatePinChallenge) {
         loginHandler.handleDidAuthenticateUser()
         registrationHandler.handleDidReceivePinRegistrationChallenge(challenge)
     }
-    
-    func userClient(_: ONGUserClient, didFailToChangePinForUser profile: ONGUserProfile, error: Error) {
-        loginHandler.handleDidFailToAuthenticateUser()
-        registrationHandler.handleDidFailToRegister()
-        changePinCompletion?(error)
+
+    func userClient(_ userClient: UserClient, didStartPinChangeForUser profile: UserProfile) {
+        // Not used
+    }
+
+    func userClient(_ userClient: UserClient, didChangePinForUser profile: UserProfile) {
+        registrationHandler.handleDidRegisterUser()
+        changePinCompletion?(nil)
         changePinCompletion = nil
     }
 
-    func userClient(_ : ONGUserClient, didChangePinForUser _: ONGUserProfile) {
-        registrationHandler.handleDidRegisterUser()
-        changePinCompletion?(nil)
+    func userClient(_ userClient: UserClient, didFailToChangePinForUser profile: UserProfile, error: Error) {
+        loginHandler.handleDidFailToAuthenticateUser()
+        registrationHandler.handleDidFailToRegister()
+        changePinCompletion?(error)
         changePinCompletion = nil
     }
 }

--- a/ios/Handlers/LoginHandler.swift
+++ b/ios/Handlers/LoginHandler.swift
@@ -91,13 +91,8 @@ class loginDelegate: AuthenticationDelegate {
     func userClient(_ userClient: OneginiSDKiOS.UserClient, didFailToAuthenticateUser profile: OneginiSDKiOS.UserProfile, authenticator: OneginiSDKiOS.Authenticator, error: Error) {
         loginCompletion?(profile, error)
         loginCompletion = nil
-        switch error.code {
-            // We don't want to send a close pin event when we encounter an action already in progress
-        case ONGGenericError.actionAlreadyInProgress.rawValue:
-            return
-        default:
-            break
-        }
+        // We don't want to send a close pin event when we encounter an action already in progress
+        guard case ONGGenericError.actionAlreadyInProgress.rawValue = error.code else { return }
         BridgeConnector.shared?.toLoginHandler.handleDidFailToAuthenticateUser()
     }
 }

--- a/ios/Handlers/LoginHandler.swift
+++ b/ios/Handlers/LoginHandler.swift
@@ -1,14 +1,13 @@
 protocol BridgeToLoginHandlerProtocol: AnyObject {
-    func authenticateUser(_ profile: ONGUserProfile, authenticator: ONGAuthenticator?, completion: @escaping (ONGUserProfile, Error?) -> Void)
-    func setAuthPinChallenge(_ challenge: ONGPinChallenge?)
+    func authenticateUser(_ profile: UserProfile, authenticator: Authenticator?, completion: @escaping (UserProfile, Error?) -> Void)
+    func setAuthPinChallenge(_ challenge: PinChallenge?)
     func handlePin(_ pin: String?, completion: @escaping (Error?) -> Void)
     func cancelPinAuthentication(completion: @escaping (Error?) -> Void)
 }
 
 
 class LoginHandler: NSObject {
-    private var pinChallenge: ONGPinChallenge?
-    private var loginCompletion: ((ONGUserProfile, Error?) -> Void)?
+    private var pinChallenge: PinChallenge?
     private let pinAuthenticationEventEmitter = PinAuthenticationEventEmitter()
 
     func handlePin(_ pin: String?, completion: @escaping (Error?) -> Void) {
@@ -21,19 +20,11 @@ class LoginHandler: NSObject {
             completion(nil)
             return
         }
-        pinChallenge.sender.respond(withPin: pin, challenge: pinChallenge)
+        pinChallenge.sender.respond(with: pin, to: pinChallenge)
         completion(nil)
     }
 
-    fileprivate func mapErrorFromPinChallenge(_ challenge: ONGPinChallenge) -> Error? {
-        if let error = challenge.error, error.code != ONGAuthenticationError.touchIDAuthenticatorFailure.rawValue {
-            return error
-        } else {
-            return nil
-        }
-    }
-    
-    func handleDidReceiveChallenge(_ challenge: ONGPinChallenge) {
+    func handleDidReceiveChallenge(_ challenge: PinChallenge) {
         pinChallenge = challenge
         if let pinError = mapErrorFromPinChallenge(challenge) {
             pinAuthenticationEventEmitter.onIncorrectPin(error: pinError, remainingFailureCount: challenge.remainingFailureCount)
@@ -55,13 +46,15 @@ class LoginHandler: NSObject {
 }
 
 extension LoginHandler : BridgeToLoginHandlerProtocol {
-    func authenticateUser(_ profile: ONGUserProfile, authenticator: ONGAuthenticator? = nil, completion: @escaping (ONGUserProfile, Error?) -> Void) {
-        loginCompletion = completion
-        ONGUserClient.sharedInstance().authenticateUser(profile, authenticator: authenticator, delegate: self)
+    func authenticateUser(_ profile: UserProfile, authenticator: Authenticator? = nil, completion: @escaping (UserProfile, Error?) -> Void) {
+        let delegate = loginDelegate(loginCompletion: completion)
+        SharedUserClient.instance.authenticateUserWith(profile: profile, authenticator: authenticator, delegate: delegate)
     }
-    func setAuthPinChallenge(_ challenge: ONGPinChallenge?) {
+    
+    func setAuthPinChallenge(_ challenge: PinChallenge?) {
         pinChallenge = challenge
     }
+    
     func cancelPinAuthentication(completion: @escaping (Error?) -> Void) {
         guard let pinChallenge = self.pinChallenge else {
             completion(WrapperError.authenticationNotInProgress)
@@ -72,29 +65,48 @@ extension LoginHandler : BridgeToLoginHandlerProtocol {
     }
 }
 
-extension LoginHandler: ONGAuthenticationDelegate {
-    func userClient(_ : ONGUserClient, didReceive challenge: ONGPinChallenge) {
-        handleDidReceiveChallenge(challenge)
-    }
+class loginDelegate: AuthenticationDelegate {
 
-    func userClient(_: ONGUserClient, didReceive challenge: ONGCustomAuthFinishAuthenticationChallenge) {
-        // Will need this in the future
-    }
-
-    func userClient(_: ONGUserClient, didReceive challenge: ONGBiometricChallenge) {
-        challenge.sender.respond(withPrompt: "", challenge: challenge)
+    
+    private var loginCompletion: ((UserProfile, Error?) -> Void)?
+    
+    init(loginCompletion: ((UserProfile, Error?) -> Void)?) {
+        self.loginCompletion = loginCompletion
     }
     
-    func userClient(_ userClient: ONGUserClient, didAuthenticateUser userProfile: ONGUserProfile, authenticator: ONGAuthenticator, info customAuthInfo: ONGCustomInfo?) {
-        handleDidAuthenticateUser()
-        loginCompletion?(userProfile, nil)
-        loginCompletion = nil
+    func userClient(_ userClient: UserClient, didReceivePinChallenge challenge: PinChallenge) {
+        BridgeConnector.shared?.toLoginHandler.handleDidReceiveChallenge(challenge)
     }
     
-    func userClient(_ userClient: ONGUserClient, didFailToAuthenticateUser userProfile: ONGUserProfile, authenticator: ONGAuthenticator, error: Error) {
-        handleDidFailToAuthenticateUser()
-        // ChangePinHandler also makes use of the handle function but has it's own seperate completion callback, so let's leave the loginCompletion here.
-        loginCompletion?(userProfile, error)
+    func userClient(_ userClient: UserClient, didReceiveBiometricChallenge challenge: BiometricChallenge) {
+        challenge.sender.respond(with: "", to: challenge)
+    }
+
+    func userClient(_ userClient: OneginiSDKiOS.UserClient, didAuthenticateUser profile: OneginiSDKiOS.UserProfile, authenticator: OneginiSDKiOS.Authenticator, info customAuthInfo: OneginiSDKiOS.CustomInfo?) {
+            BridgeConnector.shared?.toLoginHandler.handleDidAuthenticateUser()
+            loginCompletion?(profile, nil)
+            loginCompletion = nil
+    }
+    
+    func userClient(_ userClient: OneginiSDKiOS.UserClient, didFailToAuthenticateUser profile: OneginiSDKiOS.UserProfile, authenticator: OneginiSDKiOS.Authenticator, error: Error) {
+        loginCompletion?(profile, error)
         loginCompletion = nil
+        switch error.code {
+            // We don't want to send a close pin event when we encounter an action already in progress
+        case ONGGenericError.actionAlreadyInProgress.rawValue:
+            return
+        default:
+            break
+        }
+        BridgeConnector.shared?.toLoginHandler.handleDidFailToAuthenticateUser()
+    }
+}
+
+
+fileprivate func mapErrorFromPinChallenge(_ challenge: PinChallenge) -> Error? {
+    if let error = challenge.error, error.code != ONGAuthenticationError.touchIDAuthenticatorFailure.rawValue {
+        return error
+    } else {
+        return nil
     }
 }

--- a/ios/Handlers/RegistrationHandler.swift
+++ b/ios/Handlers/RegistrationHandler.swift
@@ -98,9 +98,7 @@ extension RegistrationHandler {
         if let pinError = mapErrorFromPinChallenge(challenge) {
             createPinEventEmitter.onPinNotAllowed(error: pinError)
         } else {
-            guard let userProfile = challenge.userProfile else {
-                return
-            }
+            guard let userProfile = challenge.userProfile else { return }
             createPinEventEmitter.onPinOpen(profileId: userProfile.profileId, pinLength: challenge.pinLength)
         }
     }

--- a/ios/Handlers/RegistrationHandler.swift
+++ b/ios/Handlers/RegistrationHandler.swift
@@ -1,8 +1,8 @@
 class RegistrationHandler: NSObject {
-    private var createPinChallenge: ONGCreatePinChallenge?
-    private var browserRegistrationChallenge: ONGBrowserRegistrationChallenge?
-    private var customRegistrationChallenge: ONGCustomRegistrationChallenge?
-    private var signUpCompletion: ((Bool, ONGUserProfile?, Error?) -> Void)?
+    private var createPinChallenge: CreatePinChallenge?
+    private var browserRegistrationChallenge: BrowserRegistrationChallenge?
+    private var customRegistrationChallenge: CustomRegistrationChallenge?
+    private var signUpCompletion: ((Bool, UserProfile?, Error?) -> Void)?
     private let createPinEventEmitter = CreatePinEventEmitter()
     private let registrationEventEmitter = RegistrationEventEmitter()
     static let cancelCustomRegistrationNotAllowed = "Canceling the custom registration right now is not allowed. Registration is not in progress or pin creation has already started."
@@ -13,7 +13,7 @@ class RegistrationHandler: NSObject {
             completion(WrapperError.registrationNotInProgress)
             return
         }
-        browserRegistrationChallenge.sender.respond(with: url, challenge: browserRegistrationChallenge)
+        browserRegistrationChallenge.sender.respond(with: url, to: browserRegistrationChallenge)
         self.browserRegistrationChallenge = nil
         completion(nil)
     }
@@ -28,7 +28,7 @@ class RegistrationHandler: NSObject {
             completion(nil)
             return
         }
-        createPinChallenge.sender.respond(withCreatedPin: pin, challenge: createPinChallenge)
+        createPinChallenge.sender.respond(with: pin, to: createPinChallenge)
         completion(nil)
     }
 
@@ -37,12 +37,12 @@ class RegistrationHandler: NSObject {
             completion(WrapperError.registrationNotInProgress)
             return
         }
-        customRegistrationChallenge.sender.respond(withData: code, challenge: customRegistrationChallenge)
+        customRegistrationChallenge.sender.respond(with: code, to: customRegistrationChallenge)
         self.customRegistrationChallenge = nil
         completion(nil)
     }
 
-    fileprivate func mapErrorFromPinChallenge(_ challenge: ONGCreatePinChallenge) -> Error? {
+    fileprivate func mapErrorFromPinChallenge(_ challenge: CreatePinChallenge) -> Error? {
         if let error = challenge.error {
             return error
         } else {
@@ -56,13 +56,13 @@ class RegistrationHandler: NSObject {
 }
 
 extension RegistrationHandler {
-    func setCreatePinChallenge(_ challenge: ONGCreatePinChallenge?) {
+    func setCreatePinChallenge(_ challenge: CreatePinChallenge?) {
         createPinChallenge = challenge
     }
     
-    func signUp(identityProvider: ONGIdentityProvider? = nil, scopes: [String], completion: @escaping (Bool, ONGUserProfile?, Error?) -> Void) {
+    func signUp(identityProvider: IdentityProvider? = nil, scopes: [String], completion: @escaping (Bool, UserProfile?, Error?) -> Void) {
         signUpCompletion = completion
-        ONGUserClient.sharedInstance().registerUser(with: identityProvider, scopes: scopes, delegate: self)
+        SharedUserClient.instance.registerUserWith(identityProvider: identityProvider, scopes: scopes, delegate: self)
     }
 
     func cancelCustomRegistration(completion: @escaping (Error?) -> Void) {
@@ -93,12 +93,15 @@ extension RegistrationHandler {
         completion(nil)
     }
     
-    func handleDidReceivePinRegistrationChallenge(_ challenge: ONGCreatePinChallenge) {
+    func handleDidReceivePinRegistrationChallenge(_ challenge: CreatePinChallenge) {
         createPinChallenge = challenge
         if let pinError = mapErrorFromPinChallenge(challenge) {
             createPinEventEmitter.onPinNotAllowed(error: pinError)
         } else {
-            createPinEventEmitter.onPinOpen(profileId: challenge.userProfile.profileId, pinLength: challenge.pinLength)
+            guard let userProfile = challenge.userProfile else {
+                return
+            }
+            createPinEventEmitter.onPinOpen(profileId: userProfile.profileId, pinLength: challenge.pinLength)
         }
     }
     
@@ -118,17 +121,18 @@ extension RegistrationHandler {
     }
 }
 
-extension RegistrationHandler: ONGRegistrationDelegate {
-    func userClient(_: ONGUserClient, didReceive challenge: ONGBrowserRegistrationChallenge) {
+extension RegistrationHandler: RegistrationDelegate {
+    
+    func userClient(_ userClient: UserClient, didReceiveCreatePinChallenge challenge: CreatePinChallenge) {
+        handleDidReceivePinRegistrationChallenge(challenge)
+    }
+    
+    func userClient(_ userClient: UserClient, didReceiveBrowserRegistrationChallenge challenge: BrowserRegistrationChallenge) {
         browserRegistrationChallenge = challenge
         registrationEventEmitter.onSendUrl(challenge.url)
     }
-
-    func userClient(_: ONGUserClient, didReceivePinRegistrationChallenge challenge: ONGCreatePinChallenge) {
-        handleDidReceivePinRegistrationChallenge(challenge)
-    }
-
-    func userClient(_: ONGUserClient, didReceiveCustomRegistrationInitChallenge challenge: ONGCustomRegistrationChallenge) {
+    
+    func userClient(_ userClient: UserClient, didReceiveCustomRegistrationInitChallenge challenge: CustomRegistrationChallenge) {
         customRegistrationChallenge = challenge
 
         let result = NSMutableDictionary()
@@ -136,8 +140,8 @@ extension RegistrationHandler: ONGRegistrationDelegate {
 
         sendCustomRegistrationNotification(CustomRegistrationNotification.initRegistration, result)
     }
-
-    func userClient(_: ONGUserClient, didReceiveCustomRegistrationFinish challenge: ONGCustomRegistrationChallenge) {
+    
+    func userClient(_ userClient: UserClient, didReceiveCustomRegistrationFinishChallenge challenge: CustomRegistrationChallenge) {
         customRegistrationChallenge = challenge
 
         let result = NSMutableDictionary()
@@ -154,16 +158,15 @@ extension RegistrationHandler: ONGRegistrationDelegate {
         sendCustomRegistrationNotification(CustomRegistrationNotification.finishRegistration, result)
     }
     
-    func userClient(_ userClient: ONGUserClient, didRegisterUser userProfile: ONGUserProfile, identityProvider: ONGIdentityProvider, info: ONGCustomInfo?) {
+    func userClient(_ userClient: UserClient, didRegisterUser profile: UserProfile, with identityProvider: IdentityProvider, info: CustomInfo?) {
         handleDidRegisterUser()
-        signUpCompletion?(true, userProfile, nil)
+        signUpCompletion?(true, profile, nil)
         signUpCompletion = nil
     }
     
-    func userClient(_ userClient: ONGUserClient, didFailToRegisterWith identityProvider: ONGIdentityProvider, error: Error) {
+    func userClient(_ userClient: UserClient, didFailToRegisterUserWith identityProvider: IdentityProvider, error: Error) {
         handleDidFailToRegister()
         signUpCompletion?(false, nil, error)
         signUpCompletion = nil
     }
-
 }

--- a/ios/RNOneginiSdk.swift
+++ b/ios/RNOneginiSdk.swift
@@ -141,12 +141,10 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
                       scopes: [String],
                       resolver resolve: @escaping RCTPromiseResolveBlock,
                       rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        var provider: ONGIdentityProvider? = nil
-
+        var provider: IdentityProvider? = nil
         if identityProviderId != nil {
-            provider = userClient.identityProviders().first(where: { $0.value(forKey: "identifier") as? String == identityProviderId })
+            provider = SharedUserClient.instance.identityProviders.first(where: { $0.identifier == identityProviderId })
         }
-
         bridgeConnector.toRegistrationConnector.registrationHandler.signUp(identityProvider: provider, scopes: scopes) {
           (_, userProfile, error) -> Void in
             self.resolveResultOrRejectError(resolve, reject, ["id": userProfile?.profileId], error)
@@ -241,13 +239,13 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
     func authenticateUser(_ profileId: String, authenticatorId: String,
                         resolver resolve: @escaping RCTPromiseResolveBlock,
                         rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        let profile = userClient.userProfiles().first(where: { $0.profileId == profileId })
+        let profile = SharedUserClient.instance.userProfiles.first(where: { $0.profileId == profileId })
         guard let profile = profile else {
             rejectWithError(reject, WrapperError.profileDoesNotExist)
             return
         }
-        let authenticators = userClient.allAuthenticators(forUser: profile)
-        let authenticator = authenticators.first(where: {$0.identifier == authenticatorId}) ?? userClient.preferredAuthenticator
+        let authenticators = SharedUserClient.instance.authenticators(.all, for: profile)
+        let authenticator = authenticators.first(where: {$0.identifier == authenticatorId}) ?? SharedUserClient.instance.preferredAuthenticator
         bridgeConnector.toLoginHandler.authenticateUser(profile, authenticator: authenticator) {
             (userProfile, error) -> Void in
             self.resolveResultOrRejectError(resolve, reject, ["userProfile": ["id": userProfile.profileId]], error)
@@ -333,13 +331,14 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
     func getAllAuthenticators(_ profileId: String,
                         resolver resolve: @escaping RCTPromiseResolveBlock,
                         rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        let profile = userClient.userProfiles().first(where: { $0.profileId == profileId })
+        
+        let profile = SharedUserClient.instance.userProfiles.first(where: { $0.profileId == profileId })
         guard let profile = profile else {
             rejectWithError(reject, WrapperError.profileDoesNotExist)
             return
         }
         
-        let allAuthenticators: Array<ONGAuthenticator> = bridgeConnector.toAuthenticatorsHandler.getAuthenticatorsListForUserProfile(profile)
+        let allAuthenticators: Array<Authenticator> = bridgeConnector.toAuthenticatorsHandler.getAuthenticatorsListForUserProfile(profile)
 
         let result: NSMutableArray = []
 
@@ -354,13 +353,13 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
     func getRegisteredAuthenticators(_ profileId: String,
                         resolver resolve: @escaping RCTPromiseResolveBlock,
                         rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        let profile = userClient.userProfiles().first(where: { $0.profileId == profileId })
+        let profile = SharedUserClient.instance.userProfiles.first(where: { $0.profileId == profileId })
         guard let profile = profile else {
             rejectWithError(reject, WrapperError.profileDoesNotExist)
             return
         }
 
-        let registeredAuthenticators: Array<ONGAuthenticator> = bridgeConnector.toAuthenticatorsHandler.getAuthenticatorsListForUserProfile(profile).filter {$0.isRegistered == true}
+        let registeredAuthenticators: Array<Authenticator> = bridgeConnector.toAuthenticatorsHandler.getAuthenticatorsListForUserProfile(profile).filter {$0.isRegistered == true}
 
         let result: NSMutableArray = []
 
@@ -375,7 +374,7 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
     func setPreferredAuthenticator(_ profileId: String, authenticatorId: String,
                         resolver resolve: @escaping RCTPromiseResolveBlock,
                         rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        let profile = userClient.userProfiles().first(where: { $0.profileId == profileId })
+        let profile = SharedUserClient.instance.userProfiles.first(where: { $0.profileId == profileId })
         guard let profile = profile else {
             rejectWithError(reject, WrapperError.profileDoesNotExist)
             return
@@ -396,7 +395,7 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
     func registerAuthenticator(_ authenticatorId: String,
                         resolver resolve: @escaping RCTPromiseResolveBlock,
                         rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        let profile = userClient.authenticatedUserProfile()
+        let profile = SharedUserClient.instance.authenticatedUserProfile
         guard let profile = profile else {
             rejectWithError(reject, WrapperError.profileDoesNotExist)
             return
@@ -409,7 +408,7 @@ class RNOneginiSdk: RCTEventEmitter, ConnectorToRNBridgeProtocol {
     func deregisterAuthenticator(_ authenticatorId: String,
                         resolver resolve: @escaping RCTPromiseResolveBlock,
                         rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        let profile = userClient.authenticatedUserProfile()
+        let profile = SharedUserClient.instance.authenticatedUserProfile
         guard let profile = profile else {
             reject(String(WrapperError.noProfileAuthenticated.code), WrapperError.noProfileAuthenticated.localizedDescription, WrapperError.noProfileAuthenticated)
             return


### PR DESCRIPTION
Previously, it was possible to deadlock authentication by starting authentication during another authentication flow. To fix this, we need to save the completion with the authentication delegate so we can start a new authentication and reject the correct promise.
Due to some issues with deinitalization of the delegate with the objc api we also convert all the login/regiter/changepin/authenticators logic to the swift api because this api already keeps a reference to the delegate so we don't have to do that ourselves to prevent it from getting de-initalized.